### PR TITLE
Remove: unneccesary logo in Footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -8,9 +8,6 @@ const Footer = () => {
     <footer className="flexCenter mb-24">
       <div className="padding-container max-container flex w-full flex-col gap-14">
         <div className="flex flex-col items-start justify-center gap-[10%] md:flex-row">
-          <Link href="/" className="mb-10">
-            <Image src="/hilink-logo.svg" alt="logo" width={74} height={29} />
-          </Link>
           <div className="flex flex-wrap gap-10 sm:justify-between md:flex-1">
             {FOOTER_LINKS.map((columns) => (
               <FooterColumn title={columns.title}>


### PR DESCRIPTION
part 2

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the logo from the footer component in the application.
> 
> ## What changed
> The HiLink logo that was previously displayed in the footer has been removed. The code for the logo and its associated link has been deleted from the Footer.tsx file.
> 
> ```diff
> -          <Link href="/" className="mb-10">
> -            <Image src="/hilink-logo.svg" alt="logo" width={74} height={29} />
> -          </Link>
> ```
> 
> ## How to test
> To test this change, follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Run the application.
> 3. Navigate to any page and scroll down to the footer.
> 4. Confirm that the HiLink logo is no longer displayed in the footer.
> 
> ## Why make this change
> This change was made to simplify the footer and remove unnecessary branding. The logo is already displayed prominently in the header of the application, so it was deemed unnecessary to also include it in the footer.
</details>