### PR TITLE
Fix: Camping Spot naming

### DIFF
--- a/components/Guide.tsx
+++ b/components/Guide.tsx
@@ -43,11 +43,11 @@ const Guide = () => {
                 <p className="regular-16 text-gray-20">Destination</p>
                 <p className="bold-16 text-green-50">48 min</p>
               </div>
-              <p className="bold-20 mt-2">Camping Spot</p>
+              <p className="bold-20 mt-2">Camping Spot A</p>
             </div>
             <div className="flex w-full flex-col">
               <p className="regular-16 text-gray-20">Start Track</p>
-              <h4 className="bold-20 mt-2 whitespace-nowrap">Camping Spot 2</h4>
+              <h4 className="bold-20 mt-2 whitespace-nowrap">Camping Spot B</h4>
             </div>
           </div>
         </div>


### PR DESCRIPTION
part 3

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # TL;DR
> This pull request updates the labels for camping spots in the Guide component from 'Camping Spot' and 'Camping Spot 2' to 'Camping Spot A' and 'Camping Spot B' respectively.
> 
> # What changed
> The labels for the camping spots in the Guide component were updated. The first camping spot was previously labeled as 'Camping Spot' and has been changed to 'Camping Spot A'. The second camping spot was previously labeled as 'Camping Spot 2' and has been changed to 'Camping Spot B'.
> 
> # How to test
> To test these changes, navigate to the Guide component in the application. Verify that the labels for the camping spots have been updated to 'Camping Spot A' and 'Camping Spot B'. 
> 
> # Why make this change
> This change was made to provide more clarity and consistency in the labeling of the camping spots. The previous labels ('Camping Spot' and 'Camping Spot 2') could potentially cause confusion as they do not clearly indicate the order or sequence of the camping spots. The new labels ('Camping Spot A' and 'Camping Spot B') provide a clear and consistent way to differentiate between the two camping spots.
</details>