### PR TITLE
Fix: Navbar

### DIFF
--- a/components/Guide.tsx
+++ b/components/Guide.tsx
@@ -43,11 +43,11 @@ const Guide = () => {
                 <p className="regular-16 text-gray-20">Destination</p>
                 <p className="bold-16 text-green-50">48 min</p>
               </div>
-              <p className="bold-20 mt-2">Camping Spot</p>
+              <p className="bold-20 mt-2">Camping Spot A</p>
             </div>
             <div className="flex w-full flex-col">
               <p className="regular-16 text-gray-20">Start Track</p>
-              <h4 className="bold-20 mt-2 whitespace-nowrap">Camping Spot 2</h4>
+              <h4 className="bold-20 mt-2 whitespace-nowrap">Camping Spot B</h4>
             </div>
           </div>
         </div>

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,7 +1,6 @@
 // NAVIGATION
 export const NAV_LINKS = [
   { href: "/", key: "home", label: "Home" },
-  { href: "/", key: "how_hilink_work", label: "How Hilink Work?" },
   { href: "/", key: "services", label: "Services" },
   { href: "/", key: "pricing ", label: "Pricing " },
   { href: "/", key: "contact_us", label: "Contact Us" },

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -51,7 +51,7 @@ export const FOOTER_LINKS = [
   {
     title: "Learn More",
     links: [
-      "About Hilink",
+      "About",
       "Press Releases",
       "Environment",
       "Jobs",


### PR DESCRIPTION
Fix: Navbar

Update About Hilink link in footer

Update camping spot names in Guide component

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request includes changes to the `Guide.tsx` and `index.ts` files. The changes include renaming of camping spots in the guide component and removal of a navigation link in the constants file.
> 
> ## What changed
> In `Guide.tsx`, the names of the camping spots have been changed from 'Camping Spot' and 'Camping Spot 2' to 'Camping Spot A' and 'Camping Spot B' respectively.
> 
> In `index.ts`, the navigation link 'How Hilink Work?' has been removed from the `NAV_LINKS` array. Also, the 'About Hilink' link in the `FOOTER_LINKS` array has been renamed to 'About'.
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Run the application.
> 3. Check the guide component to ensure the camping spots are correctly renamed.
> 4. Check the navigation bar and footer to ensure the links are correctly updated.
> 
> ## Why make this change
> The camping spots in the guide component were renamed to provide more clarity and specificity. The navigation link was removed as it was deemed unnecessary, and the footer link was renamed to make it more concise. These changes aim to improve the user experience by making the interface more intuitive and easy to navigate.
</details>